### PR TITLE
Optimize wallpaper transition animation loading

### DIFF
--- a/js/animation.js
+++ b/js/animation.js
@@ -701,8 +701,14 @@ class WallpaperAnimation {
       this.state = 'CLOSING';
       this.closeStartTime = Date.now();
       this.splitProgress = 1; // Start from fully open position
+    } else if (this.state === 'STATIC') {
+      // Allow starting cook transition directly from STATIC state (when loaded on Cook button press)
+      console.log("🍳 Starting COOK transition directly from static state!");
+      this.state = 'CLOSING';
+      this.closeStartTime = Date.now();
+      this.splitProgress = 1; // Start from fully closed position, will close immediately
     } else {
-      console.warn("⚠️ Cannot start cook transition - not in READY_FOR_COOK state:", this.state);
+      console.warn("⚠️ Cannot start cook transition - not in valid state:", this.state);
     }
   }
 

--- a/js/draw.js
+++ b/js/draw.js
@@ -1380,7 +1380,68 @@ let firstInactivityMessageShown = false;
     ellipse(x, y, petalSize, petalSize);
   }
 
-  // New function to draw loading animation with wallpaper tiles - APlasker
+  // Simple loading screen without wallpaper animation
+  function drawSimpleLoadingScreen() {
+    // Draw the COMPLETE start screen
+    drawTitle();
+    drawByline();
+    drawRecipeStats();
+    
+    // Draw buttons
+    if (typeof startButton !== 'undefined' && typeof tutorialButton !== 'undefined') {
+      // Position buttons for start screen
+      const cookButtonWidth = Math.max(playAreaWidth * 0.25, 120);
+      const buttonHeight = Math.max(playAreaHeight * 0.08, 40);
+      const tutorialButtonWidth = cookButtonWidth * 0.5;
+      
+      startButton.x = playAreaX + playAreaWidth * 0.5;
+      startButton.y = playAreaY + playAreaHeight * 0.88;
+      startButton.w = cookButtonWidth;
+      startButton.h = buttonHeight;
+      startButton.customCornerRadius = 12;
+      
+      tutorialButton.x = startButton.x - (cookButtonWidth/2) - (tutorialButtonWidth/2) - 20;
+      tutorialButton.y = startButton.y;
+      tutorialButton.w = tutorialButtonWidth;
+      tutorialButton.h = buttonHeight;
+      tutorialButton.customCornerRadius = 12;
+      tutorialButton.label = "First\nTime?";
+      tutorialButton.textSizeMultiplier = 0.8;
+      
+      tutorialButton.draw();
+      startButton.draw();
+    }
+    
+    // Draw version text
+    push();
+    textAlign(CENTER, CENTER);
+    const versionTextSize = Math.max(playAreaWidth * 0.016, 8);
+    textSize(versionTextSize);
+    const versionText = "v20250719.740PM.EDT - APlasker";
+    const combinedText = versionText + " | Say hi!";
+    
+    fill(100); // Gray color for version text
+    const versionWidth = textWidth(versionText);
+    const pipeWidth = textWidth(" | ");
+    const sayHiWidth = textWidth("Say hi!");
+    const totalWidth = versionWidth + pipeWidth + sayHiWidth;
+    const startX = playAreaX + playAreaWidth/2 - totalWidth/2;
+    
+    text(versionText, startX + versionWidth/2, playAreaY + playAreaHeight * 0.985);
+    fill(COLORS.primary);
+    text(" | Say hi!", startX + versionWidth + pipeWidth + sayHiWidth/2, playAreaY + playAreaHeight * 0.985);
+    pop();
+
+    // Show loading message if needed
+    if (isLoadingRecipe) {
+      fill(255);
+      textAlign(CENTER, CENTER);
+      textSize(18);
+      text("Loading recipe...", playAreaX + playAreaWidth/2, playAreaY + playAreaHeight/2 + 30);
+    }
+  }
+
+  // New function to draw loading animation with wallpaper tiles - APlasker (now deprecated)
   function drawLoadingAnimation() {
   // Always draw the COMPLETE start screen first - it's behind the wallpaper wall
   drawTitle();
@@ -1668,8 +1729,8 @@ function drawWallpaperAnimation() {
     
     // Check if we're still loading recipe data (initial loading state only)
     if (isLoadingRecipe) {
-      // Draw loading animation only during initial loading
-      drawLoadingAnimation();
+      // Draw simple loading screen without wallpaper animation
+      drawSimpleLoadingScreen();
       
       // Draw floral pattern border if there's space - moved here from outside
       drawFloralBorder();
@@ -1682,15 +1743,16 @@ function drawWallpaperAnimation() {
     
     // Check if wallpaper animation is still running (even after loading complete)
     if (wallpaperAnimationActive) {
+      // Draw floral pattern border FIRST so wallpaper appears on top
+      drawFloralBorder();
+      
+      // Draw top and bottom flowers FIRST so wallpaper appears on top
+      drawTopBottomFlowers();
+      
       const animationStillRunning = drawWallpaperAnimation();
       
       if (animationStillRunning) {
-        // Draw floral pattern border if there's space
-        drawFloralBorder();
-        
-        // Draw top and bottom flowers on narrow screens
-        drawTopBottomFlowers();
-        
+        // NOTE: drawWallpaperAnimation draws the wallpaper on top of the flowers
         return; // Don't draw normal game elements while animation is running
       }
     }

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -401,9 +401,7 @@ let intermediate_combinations = [
   function preload() {
     console.log("Preloading assets...");
     
-    // Load wallpaper SVG using HTML5 Canvas for high-quality rendering - APlasker
-    console.log("🚀 Loading wallpaper SVG via HTML5 Canvas...");
-    loadWallpaperSVGHighRes();
+    // No longer loading wallpaper during initialization - moved to Cook button press
     
     // Use web-safe fonts directly instead of trying to load Google Fonts
   titleFont = 'Courier, "Courier New", monospace';
@@ -413,16 +411,33 @@ let intermediate_combinations = [
     console.log("Using web-safe fonts instead of Google Fonts");
   }
   
+  // New function to load wallpaper specifically for Cook button with immediate timeout
+  function loadWallpaperForCook() {
+    console.log("📐 Loading SVG for Cook transition with immediate timeout...");
+    
+    // Much shorter timeout for Cook button - if it doesn't load immediately, skip animation
+    const cookLoadingTimeout = setTimeout(() => {
+      console.warn("⚠️ Wallpaper loading timeout for Cook - starting game immediately");
+      wallpaperImageReady = false;
+      actuallyStartGame(); // Start game without animation
+    }, 500); // Only 500ms timeout for immediate loading
+    
+    loadWallpaperSVGHighRes(cookLoadingTimeout, true);
+  }
+
   // Function to load SVG at high resolution using HTML5 Canvas - APlasker
-  function loadWallpaperSVGHighRes() {
+  function loadWallpaperSVGHighRes(timeoutHandle = null, forCookTransition = false) {
     console.log("📐 Loading SVG via HTML5 Canvas for maximum quality...");
     
-    // Set a timeout to prevent infinite loading - APlasker
-    const loadingTimeout = setTimeout(() => {
-      console.warn("⚠️ Wallpaper loading timeout - proceeding without animation");
-      wallpaperImageReady = false;
-      loadingComplete = true; // Allow game to continue
-    }, 5000); // 5 second timeout
+    // Set a timeout to prevent infinite loading - APlasker (only if not provided)
+    let loadingTimeout = timeoutHandle;
+    if (!loadingTimeout) {
+      loadingTimeout = setTimeout(() => {
+        console.warn("⚠️ Wallpaper loading timeout - proceeding without animation");
+        wallpaperImageReady = false;
+        loadingComplete = true; // Allow game to continue
+      }, 5000); // 5 second timeout for normal loading
+    }
     
     // Create an image element to load the SVG
     const img = new Image();
@@ -473,17 +488,38 @@ let intermediate_combinations = [
             console.log(`📐 Final p5.js image dimensions: ${wallpaperHighResImage.width}x${wallpaperHighResImage.height}`);
             wallpaperImageReady = true; // Mark image as truly ready - APlasker
             console.log("✅ Wallpaper image is now ready for animation");
+            
+            // Clear the timeout since loading succeeded
+            clearTimeout(loadingTimeout);
+            
+            // If this was for cook transition, start the animation immediately
+            if (forCookTransition) {
+              if (!wallpaperAnimation) {
+                wallpaperAnimation = new WallpaperAnimation();
+              }
+              console.log("🍳 Starting cook transition with loaded wallpaper");
+              wallpaperAnimationActive = true;
+              wallpaperAnimation.startCookTransition();
+            }
           },
           function() {
             console.log("❌ Failed to convert canvas to p5.js image - proceeding without animation");
             wallpaperImageReady = false;
-            loadingComplete = true; // Allow game to continue
+            if (forCookTransition) {
+              actuallyStartGame(); // Start game immediately if loading failed
+            } else {
+              loadingComplete = true; // Allow game to continue
+            }
           }
         );
       } catch (error) {
         console.error("❌ Error creating canvas or converting image:", error);
         wallpaperImageReady = false;
-        loadingComplete = true; // Allow game to continue
+        if (forCookTransition) {
+          actuallyStartGame(); // Start game immediately if loading failed
+        } else {
+          loadingComplete = true; // Allow game to continue
+        }
       }
     };
     
@@ -491,7 +527,11 @@ let intermediate_combinations = [
       clearTimeout(loadingTimeout); // Cancel timeout since we got an error
       console.log("❌ Failed to load SVG as DOM image - proceeding without animation");
       wallpaperImageReady = false;
-      loadingComplete = true; // Allow game to continue without wallpaper
+      if (forCookTransition) {
+        actuallyStartGame(); // Start game immediately if loading failed
+      } else {
+        loadingComplete = true; // Allow game to continue without wallpaper
+      }
     };
     
     // Start loading the SVG
@@ -771,6 +811,13 @@ let intermediate_combinations = [
     if (vessels.length === 0 || isLoadingRecipe) {
       console.log("Cannot start game yet - initialization incomplete");
       return;
+    }
+    
+    // Try to load wallpaper for animation - but with immediate timeout
+    if (!wallpaperImageReady && !wallpaperAnimation) {
+      console.log("🚀 Loading wallpaper for Cook transition...");
+      loadWallpaperForCook();
+      return; // Wait for either successful load or timeout
     }
     
     // Start cook transition if wallpaper animation exists


### PR DESCRIPTION
Defer wallpaper transition loading to the 'Cook!' button press to improve initial load time, add a quick-load timeout, and ensure it renders on top of other elements.

---

[Open in Web](https://www.cursor.com/agents?id=bc-bb1ecaf2-55e6-434d-aeed-4e935a7f5612) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-bb1ecaf2-55e6-434d-aeed-4e935a7f5612)