### PR TITLE
Update combo recipe logic

### DIFF
--- a/COMBO_LOGIC_UPDATE_SUMMARY.md
+++ b/COMBO_LOGIC_UPDATE_SUMMARY.md
@@ -1,0 +1,58 @@
+# Combo Logic Update Summary
+
+## Overview
+Updated the game logic to support flexible combination patterns where combos can be combined with other combos and/or ingredients to create new combos at any level of hierarchy.
+
+## Key Changes
+
+### 1. Unified Combination Logic in `combineVessels()`
+- **Location**: `js/GameLogic.js`
+- **Previous**: Used three separate cases (Case 1, 2, 3) for different combination types
+- **New**: Unified logic that treats all combinations equally using recipe matching
+
+#### Main improvements:
+- Removed case-based logic that artificially separated combination types
+- Created a unified `findMatchingRecipe()` function that checks if any set of items matches a recipe
+- Created a unified `createVesselFromRecipe()` function to handle vessel creation
+- Supports any combination of ingredients and combos as long as they match a recipe
+
+### 2. Updated Auto-Combination Logic
+- **Location**: `js/GameLogic.js` - `checkForParentCombinations()` function
+- **Previous**: Only checked for parent-child relationships where ALL children must be present
+- **New**: Checks all possible combinations of vessels (2 or 3 at a time) against all recipes
+
+#### Main improvements:
+- Now supports auto-combining any valid recipe match, not just parent-child relationships
+- Can auto-combine 2 or 3 vessels at once
+- Preserves the special final combination sequence (won't auto-combine the final recipe)
+
+## How It Works
+
+### Recipe Matching
+The system now uses a simple recipe matching approach:
+1. Extract all items from the vessels being combined (base ingredients + combo names)
+2. Check if these items exactly match any recipe's requirements
+3. If yes, create the new combo
+4. If partial match, create a yellow vessel showing progress
+
+### Example Combinations Now Supported:
+- `Tomato + Basil → Tomato Sauce` (base ingredients to combo)
+- `Tomato Sauce + Garlic → Special Sauce` (combo + ingredient to new combo) 
+- `Tomato Sauce + Cheese Sauce → Pizza Sauce` (combo + combo to new combo)
+- `Base + Sauce + Topping → Pizza` (multiple items to combo)
+
+## Database Structure (No Changes Needed)
+The existing Supabase structure already supports this with:
+- `combinations` table with `parent_combo` field for hierarchical relationships
+- `ingredients` table linking ingredients to combinations via `combo_id`
+- The game now properly uses these relationships
+
+## Testing Recommendations
+1. Create a recipe with nested combos in admin-tree
+2. Test that combos can combine with other combos
+3. Test that combos can combine with additional ingredients
+4. Verify auto-combination works for complex recipes
+5. Ensure the final combination animation sequence is preserved
+
+## No Visual Changes
+As requested, there are no visual distinctions for combos that can be further combined - all completed combos look the same regardless of whether they're final products or intermediate steps.


### PR DESCRIPTION
Unify and enhance combination logic to support hierarchical recipes, allowing combos to combine with other combos and ingredients.

Previously, the game's combination logic was rigid, preventing combos from combining with other combos or additional ingredients to form new intermediate combos, despite the underlying data structure supporting such hierarchies. This PR refactors the combination and auto-combination logic to correctly interpret and utilize the `parent_combo` relationships, enabling flexible, multi-level recipe creation.

---

[Open in Web](https://www.cursor.com/agents?id=bc-0582f9f6-7037-457a-89b3-210036a3f291) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0582f9f6-7037-457a-89b3-210036a3f291)