### PR TITLE
Fix incorrect combo autocomplete animations

### DIFF
--- a/js/GameLogic.js
+++ b/js/GameLogic.js
@@ -103,7 +103,12 @@ function combineVessels(v1, v2, mouseX = null, mouseY = null) {
                               newVesselX, newVesselY, vesselWidth, vesselHeight);
             
             new_v.verb = recipe.verb || "Mix";
-            new_v.verbDisplayTime = 120;
+            // Only set verbDisplayTime for final recipe
+            if (final_combination && recipe.name === final_combination.name) {
+                new_v.verbDisplayTime = 120;
+            } else {
+                new_v.verbDisplayTime = 0;
+            }
             
             // Add to completedGreenVessels
             if (!completedGreenVessels.some(vessel => vessel.name === recipe.name)) {
@@ -1393,11 +1398,9 @@ function combineVessels(v1, v2, mouseX = null, mouseY = null) {
             }
             
             // Create verb animation for intermediate step
-            if (new_v.verb) {
-              console.log("Creating verb animation for intermediate step:", new_v.verb);
+            if (new_v.verb && final_combination && new_v.name === final_combination.name) {
               animations.push(new VerbAnimation(new_v.verb, new_v.x, new_v.y, new_v));
-              // Reset verbDisplayTime to prevent duplicate animations
-              new_v.verbDisplayTime = 0;
+              new_v.verbDisplayTime = 119; // Prevent duplicate animations
             }
             
             // Wait for the verb animation plus a little extra time before the next step
@@ -1707,8 +1710,8 @@ function combineVessels(v1, v2, mouseX = null, mouseY = null) {
             // Use bounce pulse for the newly created combination
             newVessel.bouncePulse();
             
-            // Create verb animation
-            if (newVessel.verb) {
+            // Create verb animation ONLY for final recipe combo
+            if (newVessel.verb && final_combination && newVessel.name === final_combination.name) {
               animations.push(new VerbAnimation(newVessel.verb, newVessel.x, newVessel.y, newVessel));
               newVessel.verbDisplayTime = 119; // Prevent duplicate animations
             }
@@ -1832,8 +1835,8 @@ function combineVessels(v1, v2, mouseX = null, mouseY = null) {
                 // Use bounce pulse for the newly created combination
                 newVessel.bouncePulse();
                 
-                // Create verb animation
-                if (newVessel.verb) {
+                // Create verb animation ONLY for final recipe combo
+                if (newVessel.verb && final_combination && newVessel.name === final_combination.name) {
                   animations.push(new VerbAnimation(newVessel.verb, newVessel.x, newVessel.y, newVessel));
                   newVessel.verbDisplayTime = 119; // Prevent duplicate animations
                 }

--- a/js/draw.js
+++ b/js/draw.js
@@ -2703,12 +2703,12 @@ function drawWallpaperAnimation() {
       console.log("No verb found, using default verb 'Mix'");
     }
     
-    // Create the animation directly instead of waiting for displayVerb to be called
-    console.log("Creating immediate verb animation for:", vessel.verb, "at position", vessel.x, vessel.y);
-    animations.push(new VerbAnimation(vessel.verb, vessel.x, vessel.y, vessel));
+    // Don't create verb animation for non-final combos
+    // Only the final combo should show the autocomplete animation
+    console.log("Not creating verb animation for non-final vessel:", vessel.name);
     
-    // Set verbDisplayTime to 119 to prevent duplicate animations from displayVerb()
-    vessel.verbDisplayTime = 119;
+    // Set verbDisplayTime to 0 to prevent any animation from displayVerb()
+    vessel.verbDisplayTime = 0;
     
     return true;
   }

--- a/js/interaction.js
+++ b/js/interaction.js
@@ -1779,22 +1779,18 @@ function mouseReleased() {
           // For green vessels (completed combinations), prioritize verb animation
           // But skip creating regular VerbAnimation if this is the final combo (we'll use FinalVerbAnimation instead)
           if (!isFinalCombination) {
-            console.log("Completed combination - using verb animation directly");
+            console.log("Non-final combination - skipping verb animation");
             
-            // Check if the vessel has a verb
+            // Set the verb but don't create animation
             if (new_v.verb) {
-              console.log("Creating immediate verb animation for:", new_v.verb);
-              // Create verb animation starting exactly at the vessel's center
-              animations.push(new VerbAnimation(new_v.verb, new_v.x, new_v.y, new_v));
-              // Reset the verbDisplayTime to prevent duplicate animations
-              new_v.verbDisplayTime = 119; // Set to 119 instead of 120 to prevent creating another animation
+              console.log("Vessel has verb:", new_v.verb, "but not creating animation");
             } else {
               // If no verb is set, use a default verb
               console.log("No verb found, using default verb");
               new_v.verb = "Mix";
-              new_v.verbDisplayTime = 119;
-              animations.push(new VerbAnimation(new_v.verb, new_v.x, new_v.y, new_v));
             }
+            // Set verbDisplayTime to 0 to prevent any animations
+            new_v.verbDisplayTime = 0;
           } else {
             console.log("Final combination detected - skipping regular verb animation");
             // Still set verbDisplayTime to prevent auto-animation


### PR DESCRIPTION
Restrict autocomplete (verb) animations to only the final recipe combo.

Previously, `VerbAnimation` was triggered for all completed combos, leading to unwanted "autocomplete" reveals for intermediate steps. This PR ensures only the final recipe combo gets this animation, as per user requirements.

---

[Open in Web](https://www.cursor.com/agents?id=bc-a7ac8df9-3689-4253-9136-1ba1072b341d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a7ac8df9-3689-4253-9136-1ba1072b341d)