### PR TITLE
Fix cloudflare worker syntax error

### DIFF
--- a/cloudflare-worker.js
+++ b/cloudflare-worker.js
@@ -1,0 +1,33 @@
+export default {
+  async fetch(request, env, ctx) {
+    // Get the original response
+    const response = await fetch(request);
+    
+    // Only modify HTML responses
+    const contentType = response.headers.get('content-type');
+    if (!contentType || !contentType.includes('text/html')) {
+      return response;
+    }
+    
+    // Get the HTML content
+    let html = await response.text();
+    
+    // Inject the Supabase credentials
+    const injection = `
+    <script>
+      window.SUPABASE_URL = '${env.SUPABASE_URL}';
+      window.SUPABASE_ANON_KEY = '${env.SUPABASE_ANON_KEY}';
+    </script>`;
+    
+    // Replace the config.js script tag with our injection
+    html = html.replace(
+      '<script src="js/config.js"></script>',
+      injection
+    );
+    
+    // Return modified response
+    return new Response(html, {
+      headers: response.headers
+    });
+  }
+};


### PR DESCRIPTION
Fix `SyntaxError: Missing } in template expression` in Cloudflare Worker code.

The original code in the `SECURITY_IMPLEMENTATION_GUIDE.md` Step 3.2 had an issue with template literal syntax when injecting Supabase environment variables, leading to a `SyntaxError`. This PR provides the corrected Cloudflare Worker code.

---

[Open in Web](https://www.cursor.com/agents?id=bc-4f700e78-f874-4e30-a4e7-5f03ce2db9d0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4f700e78-f874-4e30-a4e7-5f03ce2db9d0)